### PR TITLE
Add archiver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,6 @@ gem "colorize"
 gem "nokogiri"
 gem "open-uri-cached"
 gem "fuzzy_match"
+gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'
 gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby', branch: 'morph_defaults'
 gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'

--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,15 @@
 # Find out more: https://morph.io/documentation/ruby
 
 source "https://rubygems.org"
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ruby "2.0.0"
 
-gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby.git", branch: "morph_defaults"
 gem "execjs"
 gem "pry"
 gem "colorize"
 gem "nokogiri"
 gem "open-uri-cached"
 gem "fuzzy_match"
+gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby', branch: 'morph_defaults'
 gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,32 +10,32 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.1.0)
-    colorize (0.7.7)
-    excon (0.45.4)
-    execjs (2.5.2)
-    faraday (0.9.1)
+    coderay (1.1.1)
+    colorize (0.8.1)
+    excon (0.54.0)
+    execjs (2.7.0)
+    faraday (0.10.0)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.0)
-      faraday (>= 0.7.4, < 0.10)
+    faraday_middleware (0.10.1)
+      faraday (>= 0.7.4, < 1.0)
     fuzzy_match (2.1.0)
-    hashie (3.4.2)
-    httpclient (2.6.0.1)
+    hashie (3.4.6)
+    httpclient (2.8.2.4)
     method_source (0.8.2)
-    mini_portile (0.6.2)
+    mini_portile2 (2.1.0)
     multipart-post (2.0.0)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
     open-uri-cached (0.0.5)
-    pry (0.10.1)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
     slop (3.6.0)
-    sqlite3 (1.3.10)
-    sqlite_magic (0.0.3)
+    sqlite3 (1.3.12)
+    sqlite_magic (0.0.6)
       sqlite3
-    wikidata-client (0.0.7)
+    wikidata-client (0.0.10)
       excon (~> 0.40)
       faraday (~> 0.9)
       faraday_middleware (~> 0.9)
@@ -53,3 +53,9 @@ DEPENDENCIES
   pry
   scraperwiki!
   wikidata-client (~> 0.0.7)
+
+RUBY VERSION
+   ruby 2.0.0p648
+
+BUNDLED WITH
+   1.13.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/everypolitician/scraped_page_archive.git
+  revision: 28f93d74b1c11ef01463ad0e7f874050d2e7fc73
+  specs:
+    scraped_page_archive (0.5.0)
+      git (~> 1.3.0)
+      vcr-archive (~> 0.3.0)
+
+GIT
   remote: https://github.com/openaustralia/scraperwiki-ruby.git
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
@@ -10,8 +18,12 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     coderay (1.1.1)
     colorize (0.8.1)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     excon (0.54.0)
     execjs (2.7.0)
     faraday (0.10.0)
@@ -19,6 +31,8 @@ GEM
     faraday_middleware (0.10.1)
       faraday (>= 0.7.4, < 1.0)
     fuzzy_match (2.1.0)
+    git (1.3.0)
+    hashdiff (0.3.0)
     hashie (3.4.6)
     httpclient (2.8.2.4)
     method_source (0.8.2)
@@ -31,10 +45,20 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    public_suffix (2.0.4)
+    safe_yaml (1.0.4)
     slop (3.6.0)
     sqlite3 (1.3.12)
     sqlite_magic (0.0.6)
       sqlite3
+    vcr (3.0.3)
+    vcr-archive (0.3.0)
+      vcr (~> 3.0.2)
+      webmock (~> 2.0.3)
+    webmock (2.0.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     wikidata-client (0.0.10)
       excon (~> 0.40)
       faraday (~> 0.9)
@@ -51,6 +75,7 @@ DEPENDENCIES
   nokogiri
   open-uri-cached
   pry
+  scraped_page_archive!
   scraperwiki!
   wikidata-client (~> 0.0.7)
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,6 +1,5 @@
 #!/bin/env ruby
 # encoding: utf-8
-
 require 'scraperwiki'
 require 'nokogiri'
 require 'date'
@@ -15,7 +14,7 @@ require 'csv'
 require 'scraped_page_archive/open-uri'
 
 def noko(url)
-  Nokogiri::HTML(open(url).read) 
+  Nokogiri::HTML(open(url).read)
 end
 
 def scrape_page(url)
@@ -36,7 +35,7 @@ def scrape_party(party_url, party_name, member_count)
   mps = member_page.css('.article-content p') if mps.count.zero?
   warn "#{party_url} should have #{member_count} MPs; have #{mps.count}" unless mps.count == member_count
   mps.each do |mp|
-    data = { 
+    data = {
       name: mp.text.gsub(/^\d+\.\s*/,'').upcase,
       party: party_name,
       party_id: CGI.parse(URI.parse(party_url).query)['id'].first,

--- a/scraper.rb
+++ b/scraper.rb
@@ -10,8 +10,9 @@ require 'date'
 require 'colorize'
 require 'pry'
 require 'csv'
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
+# require 'open-uri/cached'
+# OpenURI::Cache.cache_path = '.cache'
+require 'scraped_page_archive/open-uri'
 
 def noko(url)
   Nokogiri::HTML(open(url).read) 

--- a/scraper.rb
+++ b/scraper.rb
@@ -49,4 +49,4 @@ def scrape_party(party_url, party_name, member_count)
   end
 end
 
-scrape_page 'http://www.assemblee.ne/index.php?option=com_content&view=article&id=165&Itemid=154'
+scrape_page 'http://www.assemblee.ne/index.php/organes/les-deputes'


### PR DESCRIPTION
This PR adds the archiver to the scraper.

The old url doesn't exist anymore. This PR updates only the url for the sake of the archiving, but doesn't update the scraper to actually scrape the new url layout. 

Since the data for the old term doesn't seem to be in the official site anymore, it would have to be archived into a manual file in EP-data.

The new page contains only the names of the deputies elected after the new elections.

Scraper page
------------

* [x] scraper is on Morph.io under the "everypolitician-scrapers" group <https://morph.io/everypolitician-scrapers/niger-assemblee>
* [x] scraper's GitHub "Website" link points at morph.io page <https://github.com/everypolitician-scrapers/niger-assemblee>
* [x] scraper is set to auto-run <https://morph.io/everypolitician-scrapers/niger-assemblee/settings>
* [x] scraper has webhook set _(usually only set on Wikidata person-data scrapers)_
* [x] scraper is configured for archiving _(unless source doesn't require that)_

Scraped page archive
--------------------

* [x] scraper uses scraped archive gem (unless upstream source has its own archive)
* [x] repo URL uses `https` not `git@` (until [#37 is solved](https://github.com/everypolitician/scraped_page_archive/issues/37)) 
* [x] all gemfile links are secure (e.g., use https)
* [x] morph is configured to write to GitHub ("secret" environment vars) <https://morph.io/everypolitician-scrapers/niger-assemblee/settings>
* [x] pages are archived in new branch of correct scraper repo <https://github.com/everypolitician-scrapers/niger-assemblee/tree/scraped-pages-archive/www.assemblee.ne>
